### PR TITLE
feat(instant match syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ fact(10); // 3628800
 
 Clear and simple right?
 
+Alternatively, `match(<input>, patternSpecification)` can be used to instantly perform a match:
+
+```js
+function fact(n){
+  return match(n, {
+    [when(0)]: 1,
+    [when()]: (n) => n * fact(n-1)
+  });
+}
+
+fact(10); // 3628800
+```
+
 <p align="center">
 <img style="width:100%" src="https://cloud.githubusercontent.com/assets/138050/12031158/0e37afda-ae09-11e5-9462-873b45cbb2b4.gif">
 </p>
@@ -142,7 +155,6 @@ I will accept PR with their associated tests for the following features:
 
 
 - define and implement some syntax to support wildcards
-- try and maybe support `match(input, {patterns...})` syntax instead of `match({patterns...})(input)`?
 
 [todo-list inspired by pattern-match from dherman](https://github.com/dherman/pattern-match#patterns).
 

--- a/match.js
+++ b/match.js
@@ -21,7 +21,10 @@ function MissingCatchAllPattern() {
 
 MissingCatchAllPattern.prototype = Object.create(Error.prototype);
 
-function match(obj){
+function match(/* args... */){
+  const args = Array.from(arguments),
+    obj = args[args.length-1];
+
   // pre-compute matchers
   let matchers = [];
 
@@ -36,7 +39,7 @@ function match(obj){
   // add catch-all pattern at the end
   matchers.push(when.unserialize(_catchAllSymbol, obj[_catchAllSymbol]));
 
-  return function(input){
+  const calculateResult = function(input){
     for (let i = 0, iM = matchers.length; i < iM; i++) { // old school #perf
       const matcher = matchers[i];
       if(matcher.match(input)){
@@ -45,6 +48,7 @@ function match(obj){
     }
   };
 
+  return args.length === 2 ? calculateResult(args[0]) : calculateResult;
 }
 
 function when(props){

--- a/match.test.js
+++ b/match.test.js
@@ -15,6 +15,31 @@ describe('match', () => {
     })));
   });
 
+  describe('match(<input>, specification)', () => {
+    it('instantly performs the match, rather than returning a function', function () {
+      t.strictEqual(
+        match('value', {
+          [when('value')]: 42,
+          [when()]: 99
+        }),
+        42
+      );
+    });
+
+    describe('the example in the docs', function () {
+      it('works correctly', function () {
+        function fact(n){
+          return match(n, {
+            [when(0)]: 1,
+            [when()]: (n) => n * fact(n-1)
+          });
+        }
+
+        t.deepEqual(fact(10), 3628800);
+      });
+    });
+  });
+
   describe('matching', () => {
     it('should match objects based on properties', () => {
       const output = input.map(match({


### PR DESCRIPTION
I kept the old `match` API around as well since it's really useful for defining functions that only do pattern matches.
